### PR TITLE
Add the function getPlayerSummaries(options)

### DIFF
--- a/lib/registeredApiMethods.js
+++ b/lib/registeredApiMethods.js
@@ -17,6 +17,8 @@ exports.getItemIconPath = getItemIconPath;
 exports.getRarities = getRarities;
 exports.getHeroes = getHeroes;
 exports.getTournamentPrizePool = getTournamentPrizePool;
+exports.getPlayerSummaries = getPlayerSummaries;
+
 function getLeagueListing(options) {
     var validOptionKeys = ['language'];
     var path = 'IDOTA2Match_' + this.ID + '/GetLeagueListing/v1';
@@ -117,6 +119,14 @@ function getTournamentPrizePool(options) {
     return this._request(path, validOptionKeys, options);
 }
 
+function getPlayerSummaries(options) {
+    options.steamids = (parseInt(options.steamids) + 76561197960265728).toString();
+    var validOptionKeys = ['steamids'];
+    var path = 'ISteamUser'+ '/GetPlayerSummaries/v0002';
+
+    return this._request(path, validOptionKeys, options);
+}
+
 exports.default = {
     getLeagueListing: getLeagueListing,
     getLiveLeagueGames: getLiveLeagueGames,
@@ -131,5 +141,6 @@ exports.default = {
     getItemIconPath: getItemIconPath,
     getRarities: getRarities,
     getHeroes: getHeroes,
-    getTournamentPrizePool: getTournamentPrizePool
+    getTournamentPrizePool: getTournamentPrizePool,
+    getPlayerSummaries: getPlayerSummaries
 };


### PR DESCRIPTION
Add the function getPlayerSummaries to get the player information by dota2 account id.
I need to use dota2-api to get the information of players and matches but the original package does not have the method to get the player's username or player's image. So I add this function.